### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/WaveshareSharpDustSensor.h
+++ b/WaveshareSharpDustSensor.h
@@ -4,7 +4,7 @@
 #define _WAVESHARESHARPDUSTSENSOR_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
On a filename case-sensitive operating system like Linux, use of the incorrect filename case in an `#include` directive causes compilation to fail:
```
/tmp/774189247/custom/wavesharesharpdustsensor/WaveshareSharpDustSensor.h:7:22: fatal error: arduino.h: No such file or directory

#include "arduino.h"
```